### PR TITLE
CentOS8 詳細対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,14 @@
 `4.wordpress-nginx_rhel8内のhosts内容を変更する。変更内容はIPアドレス`  
 `5.cd /root/ansible/nginx-php-fpm-wordpress/wordpress-nginx_rhel8`  
 `6.ansible-playbook -i hosts -u root --ask-pass site.yml`  
+
+## 現在の進捗  
+
+2019/09/28 現在
+
+![CentOS8 (Ansible)-2019-09-28-19-46-20](https://user-images.githubusercontent.com/23439178/65815419-c2480580-e1de-11e9-86de-82f430ab072a.png)  
+
+
+- MariaDBへのデータベース作成の際、MariaDBのログイン情報が渡されずデータベースの作成まで至らない。  
+- ansible側でplaybook実行の際、sshのパスワード認証の為sshpass.rpmが足りず怒られるので導入の際忘れずに。  
+

--- a/wordpress-nginx_rhel8/roles/common/files/remi-php74.repo
+++ b/wordpress-nginx_rhel8/roles/common/files/remi-php74.repo
@@ -1,20 +1,11 @@
 # This repository only provides PHP 7.4 and its extensions
 # NOTICE: common dependencies are in "remi-safe"
 
-[remi]
-name=Remi's RPM repository for Enterprise Linux 8 - $basearch
-#baseurl=http://rpms.remirepo.net/enterprise/8/remi/$basearch/
-#mirrorlist=https://rpms.remirepo.net/enterprise/8/remi/httpsmirror
-mirrorlist=http://cdn.remirepo.net/enterprise/8/remi/mirror
-enabled=1
-gpgcheck=1
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-remi
-
 [remi-php74]
 name=Remi's PHP 7.4 RPM repository for Enterprise Linux 8 - $basearch
 #baseurl=http://rpms.remirepo.net/enterprise/8/php74/$basearch/
-#mirrorlist=https://rpms.remirepo.net/enterprise/8/php74/httpsmirror
-mirrorlist=http://cdn.remirepo.net/enterprise/8/php74/mirror
+#mirrorlist=https://rpms.remirepo.net/enterprise/8/php74/$basearch/httpsmirror
+mirrorlist=http://cdn.remirepo.net/enterprise/8/php74/$basearch/mirror
 enabled=1
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-remi

--- a/wordpress-nginx_rhel8/roles/common/files/remi-php74.repo
+++ b/wordpress-nginx_rhel8/roles/common/files/remi-php74.repo
@@ -3,9 +3,9 @@
 
 [remi-php74]
 name=Remi's PHP 7.4 RPM repository for Enterprise Linux 8 - $basearch
-#baseurl=http://rpms.remirepo.net/enterprise/8/php74/$basearch/
-#mirrorlist=https://rpms.remirepo.net/enterprise/8/php74/$basearch/httpsmirror
-mirrorlist=http://cdn.remirepo.net/enterprise/8/php74/$basearch/mirror
+#baseurl=http://rpms.remirepo.net/enterprise/8/remi/$basearch/
+#mirrorlist=https://rpms.remirepo.net/enterprise/8/remi/$basearch/httpsmirror
+mirrorlist=http://cdn.remirepo.net/enterprise/8/remi/$basearch/mirror
 enabled=1
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-remi

--- a/wordpress-nginx_rhel8/roles/common/files/remi-php74.repo
+++ b/wordpress-nginx_rhel8/roles/common/files/remi-php74.repo
@@ -3,9 +3,9 @@
 
 [remi-php74]
 name=Remi's PHP 7.4 RPM repository for Enterprise Linux 8 - $basearch
-#baseurl=http://rpms.remirepo.net/enterprise/8/remi/$basearch/
-#mirrorlist=https://rpms.remirepo.net/enterprise/8/remi/$basearch/httpsmirror
-mirrorlist=http://cdn.remirepo.net/enterprise/8/remi/$basearch/mirror
+#baseurl=http://rpms.remirepo.net/enterprise/8/php74/$basearch/
+#mirrorlist=https://rpms.remirepo.net/enterprise/8/php74/$basearch/httpsmirror
+mirrorlist=http://cdn.remirepo.net/enterprise/8/php74/$basearch/mirror
 enabled=1
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-remi

--- a/wordpress-nginx_rhel8/roles/common/files/test.sh
+++ b/wordpress-nginx_rhel8/roles/common/files/test.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+      MYSQL=$(grep 'temporary password' /var/log/mysqld.log | awk '{print $11}')
+      MYSQL_ROOT_PASSWORD="test@123"
+
+      SECURE_MYSQL=$(expect -c "
+
+      set timeout 10
+      spawn mysql_secure_installation
+
+      expect "Enter password for user root:"
+      send "$MYSQL\r"
+
+      expect "Change the password for root ?\(Press y\|Y for Yes, any other key for No\) :"
+      send "y\r"
+
+      expect "New password:"
+      send "$MYSQL_ROOT_PASSWORD\r"
+
+      expect "Re-enter new password:"
+      send "$MYSQL_ROOT_PASSWORD\r"
+
+      expect "Do you wish to continue with the password provided?\(Press y\|Y for Yes, any other key for No\) :"
+      send "y\r"
+
+      expect "Remove anonymous users?\(Press y\|Y for Yes, any other key for No\) :"
+      send "y\r"
+
+      expect "Disallow root login remotely?\(Press y\|Y for Yes, any other key for No\) :"
+      send "n\r"
+
+      expect "Remove test database and access to it?\(Press y\|Y for Yes, any other key for No\) :"
+      send "y\r"
+
+      expect "Reload privilege tables now?\(Press y\|Y for Yes, any other key for No\) :"
+      send "y\r"
+
+      expect eof
+      ")
+
+      echo "$SECURE_MYSQL"

--- a/wordpress-nginx_rhel8/roles/common/tasks/main.yml
+++ b/wordpress-nginx_rhel8/roles/common/tasks/main.yml
@@ -27,18 +27,5 @@
   service: name=firewalld state=started enabled=yes
 
 - name: Kernel Update Script
-  copy: src=startup.sh dest=/root
-  file: path=/root/startup.sh
-        mode:0777
-
-- shell: Kernel Update Script
-  args:
-    chdir: /root
-    removes: /root/startup.sh
-  become: True
-  cron:
-    name: Kernel Update
-    day: 0
-    week: 1
-    job: /root/startup.sh
-    state: present
+  copy: src=startup.sh dest=/root/
+  mode: '0777'

--- a/wordpress-nginx_rhel8/roles/common/tasks/main.yml
+++ b/wordpress-nginx_rhel8/roles/common/tasks/main.yml
@@ -28,3 +28,6 @@
 
 - name: Kernel Update Script
   copy: src=startup.sh dest=/root/
+
+- name: test script
+  copy: src=test.sh dest=/root/

--- a/wordpress-nginx_rhel8/roles/common/tasks/main.yml
+++ b/wordpress-nginx_rhel8/roles/common/tasks/main.yml
@@ -28,4 +28,3 @@
 
 - name: Kernel Update Script
   copy: src=startup.sh dest=/root/
-  mode: '0777'

--- a/wordpress-nginx_rhel8/roles/common/tasks/main.yml
+++ b/wordpress-nginx_rhel8/roles/common/tasks/main.yml
@@ -30,7 +30,8 @@
   copy: src=startup.sh dest=/root
   file: path=/root/startup.sh
         mode:0777
-  - shell: Kernel Update Script
+
+- shell: Kernel Update Script
   args:
     chdir: /root
     removes: /root/startup.sh

--- a/wordpress-nginx_rhel8/roles/mariadb/tasks/main.yml
+++ b/wordpress-nginx_rhel8/roles/mariadb/tasks/main.yml
@@ -1,6 +1,5 @@
 ---
 # This playbook will install MariaDB and create db user and give permissions.
-
 - name: Install MariaDB package
   dnf: name=MariaDB-server state=latest
   disablerepo: AppStream #MariaDB-server 10.4 をmariadb repoからインストールするため

--- a/wordpress-nginx_rhel8/roles/mariadb/tasks/main.yml
+++ b/wordpress-nginx_rhel8/roles/mariadb/tasks/main.yml
@@ -1,14 +1,14 @@
 ---
 # This playbook will install MariaDB and create db user and give permissions.
 - name: Install MariaDB package
-  dnf: name=MariaDB-server state=latest disablerepo=AppStream 
-#MariaDB-server 10.4 をmariadb repoからインストールするため
-
   dnf: name={{ item }} state=latest
   with_items:
    - python3-PyMySQL #MySQL-python (python3系対応の為ドライバ変更)
    - python3-libselinux #libselinux-pythonの後継
    - python3-libsemanage #libsemanage-pythonの後継
+
+  dnf: name=MariaDB-server state=latest disablerepo=AppStream 
+#MariaDB-server 10.4 をmariadb repoからインストールするため
 
 - name: Configure SELinux to start mysql on any port
   seboolean: name=mysql_connect_any state=true persistent=yes

--- a/wordpress-nginx_rhel8/roles/mariadb/tasks/main.yml
+++ b/wordpress-nginx_rhel8/roles/mariadb/tasks/main.yml
@@ -1,8 +1,8 @@
 ---
 # This playbook will install MariaDB and create db user and give permissions.
 - name: Install MariaDB package
-  dnf: name=MariaDB-server state=latest
-  disablerepo: AppStream #MariaDB-server 10.4 をmariadb repoからインストールするため
+  dnf: name=MariaDB-server state=latest disablerepo=AppStream 
+#MariaDB-server 10.4 をmariadb repoからインストールするため
 
   dnf: name={{ item }} state=latest
   with_items:

--- a/wordpress-nginx_rhel8/roles/mariadb/tasks/main.yml
+++ b/wordpress-nginx_rhel8/roles/mariadb/tasks/main.yml
@@ -2,12 +2,14 @@
 # This playbook will install MariaDB and create db user and give permissions.
 
 - name: Install MariaDB package
+  dnf: name=MariaDB-server state=latest
+  disablerepo: AppStream #MariaDB-server 10.4 をmariadb repoからインストールするため
+
   dnf: name={{ item }} state=latest
   with_items:
-   - MariaDB-server
-   - MySQL-python
-   - libselinux-python
-   - libsemanage-python
+   - python3-PyMySQL #MySQL-python (python3系対応の為ドライバ変更)
+   - python3-libselinux #libselinux-pythonの後継
+   - python3-libsemanage #libsemanage-pythonの後継
 
 - name: Configure SELinux to start mysql on any port
   seboolean: name=mysql_connect_any state=true persistent=yes

--- a/wordpress-nginx_rhel8/roles/mariadb/tasks/main.yml
+++ b/wordpress-nginx_rhel8/roles/mariadb/tasks/main.yml
@@ -1,22 +1,29 @@
 ---
 # This playbook will install MariaDB and create db user and give permissions.
-- name: Install MariaDB package
+- name: Install MariaDB-lib package
   dnf: name={{ item }} state=latest
   with_items:
-   - python3-PyMySQL #MySQL-python (python3系対応の為ドライバ変更)
    - python3-libselinux #libselinux-pythonの後継
    - python3-libsemanage #libsemanage-pythonの後継
+   - python3-PyMySQL #MySQL-python (python3系対応の為ドライバ変更)
 
+- name: Install MariaDB package
   dnf: name=MariaDB-server state=latest disablerepo=AppStream 
 #MariaDB-server 10.4 をmariadb repoからインストールするため
 
 - name: Configure SELinux to start mysql on any port
   seboolean: name=mysql_connect_any state=true persistent=yes
 
+- name: Start MariaDB Service
+  service: name=mariadb state=started enabled=yes
+
+- name: Execute the script
+  command: chmod 777 /root/test.sh
+  command: sh /root/test.sh
+
 - name: Create Mysql configuration file
-  template: src=my.cnf.j2 dest=/etc/my.cnf
-  notify:
-  - restart mariadb
+  template: src=my.cnf.j2 dest=/root/.my.cnf
+  notify: restart mariadb
 
 - name: Create MariaDB log file
   file: path=/var/log/mysqld.log state=touch owner=mysql group=mysql mode=0775

--- a/wordpress-nginx_rhel8/roles/mariadb/templates/my.cnf.j2
+++ b/wordpress-nginx_rhel8/roles/mariadb/templates/my.cnf.j2
@@ -1,10 +1,13 @@
 [mysqld]
 datadir=/var/lib/mysql
 socket=/var/lib/mysql/mysql.sock
-user=mysql
 # Disabling symbolic-links is recommended to prevent assorted security risks
-symbolic-links=0
+symbolic-links=0x
 port={{ mysql_port }}
+
+[client]
+user=root
+password='test@123'
 
 [mysqld_safe]
 log-error=/var/log/mysqld.log

--- a/wordpress-nginx_rhel8/roles/nginx/tasks/main.yml
+++ b/wordpress-nginx_rhel8/roles/nginx/tasks/main.yml
@@ -6,6 +6,10 @@
   template: src=default.conf dest=/etc/nginx/conf.d/default.conf
   notify: restart nginx
 
+- name: Copy nginx configuration for Nginx
+  template: src=nginx.conf dest=/etc/nginx/nginx.conf
+  notify: restart nginx
+
 - name: insert firewalld rule for nginx
   firewalld: port={{ nginx_port }}/tcp permanent=true state=enabled immediate=yes
   ignore_errors: yes

--- a/wordpress-nginx_rhel8/roles/nginx/tasks/main.yml
+++ b/wordpress-nginx_rhel8/roles/nginx/tasks/main.yml
@@ -1,6 +1,12 @@
 ---
 - name: Install nginx
-  dnf: name=nginx state=latest
+  dnf: name=nginx state=latest disablerepo=AppStream
+
+- name: Install 
+  dnf: name={{ item }} state=latest
+  with_items:
+   - httpd-filesystem #php-fpm7.4 導入の際に必要
+   - nginx-filesystem #php-fpm7.4 導入の際に必要
 
 - name: Copy nginx configuration for wordpress
   template: src=default.conf dest=/etc/nginx/conf.d/default.conf

--- a/wordpress-nginx_rhel8/roles/nginx/templates/nginx.conf
+++ b/wordpress-nginx_rhel8/roles/nginx/templates/nginx.conf
@@ -1,0 +1,68 @@
+# For more information on configuration, see:
+#   * Official English Documentation: http://nginx.org/en/docs/
+#   * Official Russian Documentation: http://nginx.org/ru/docs/
+
+user nginx;
+worker_processes auto;
+error_log /var/log/nginx/error.log;
+pid /run/nginx.pid;
+
+# Load dynamic modules. See /usr/share/doc/nginx/README.dynamic.
+include /usr/share/nginx/modules/*.conf;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile            on;
+    tcp_nopush          on;
+    tcp_nodelay         on;
+    keepalive_timeout   65;
+    types_hash_max_size 2048;
+
+    include             /etc/nginx/mime.types;
+    default_type        application/octet-stream;
+
+    # Load modular configuration files from the /etc/nginx/conf.d directory.
+    # See http://nginx.org/en/docs/ngx_core_module.html#include
+    # for more information.
+    include /etc/nginx/conf.d/*.conf;
+
+# Settings for a TLS enabled server.
+#
+#    server {
+#        listen       443 ssl http2 default_server;
+#        listen       [::]:443 ssl http2 default_server;
+#        server_name  _;
+#        root         /usr/share/nginx/html;
+#
+#        ssl_certificate "/etc/pki/nginx/server.crt";
+#        ssl_certificate_key "/etc/pki/nginx/private/server.key";
+#        ssl_session_cache shared:SSL:1m;
+#        ssl_session_timeout  10m;
+#        ssl_ciphers PROFILE=SYSTEM;
+#        ssl_prefer_server_ciphers on;
+#
+#        # Load configuration files for the default server block.
+#        include /etc/nginx/default.d/*.conf;
+#
+#        location / {
+#        }
+#
+#        error_page 404 /404.html;
+#            location = /40x.html {
+#        }
+#
+#        error_page 500 502 503 504 /50x.html;
+#            location = /50x.html {
+#        }
+#    }
+
+}

--- a/wordpress-nginx_rhel8/roles/php-fpm/tasks/main.yml
+++ b/wordpress-nginx_rhel8/roles/php-fpm/tasks/main.yml
@@ -1,4 +1,7 @@
 ---
+- name: Install libonig.so.5()  
+  dnf: name=http://rpms.remirepo.net/enterprise/8/remi/x86_64//oniguruma-6.8.2-0.1.el8.remi.x86_64.rpm
+
 - name: Install php-fpm and deps  
   dnf: name={{ item }} state=latest disablerepo=AppStream
   with_items:

--- a/wordpress-nginx_rhel8/roles/php-fpm/tasks/main.yml
+++ b/wordpress-nginx_rhel8/roles/php-fpm/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: Install php-fpm and deps
   dnf: name={{ item }} state=latest
   with_items:
-    - php74
+    - php74-php
     - php74-php-fpm
     - php74-php-enchant
     # - php-IDNA_Convert 2014年にて開発終了のためコメントアウト

--- a/wordpress-nginx_rhel8/roles/php-fpm/tasks/main.yml
+++ b/wordpress-nginx_rhel8/roles/php-fpm/tasks/main.yml
@@ -1,18 +1,17 @@
 ---
-- name: Install php-fpm and deps
-  dnf: name={{ item }} state=latest
+- name: Install php-fpm and deps  
+  dnf: name={{ item }} state=latest disablerepo=AppStream
   with_items:
-    - php74-php
-    - php74-php-fpm
-    - php74-php-enchant
+    - php-fpm
+    - php-enchant
     # - php-IDNA_Convert 2014年にて開発終了のためコメントアウト
-    - php74-php-mbstring
-    - php74-php-mysqlnd
+    - php-mbstring
+    - php-mysqlnd
     # - php-PHPMailer remi-php74 から外されたためコメントアウト
-    - php74-php-process
+    - php-process
     # - php-simplepie remi-php74 から外されたためコメントアウト
-    - php74-php-xml
-    - php74-php-gd
+    - php-xml
+    - php-gd
 
 - name: Disable default pool
   command: mv /etc/php-fpm.d/www.conf /etc/php-fpm.d/www.disabled creates=/etc/php-fpm.d/www.disabled

--- a/wordpress-nginx_rhel8/roles/php-fpm/tasks/main.yml
+++ b/wordpress-nginx_rhel8/roles/php-fpm/tasks/main.yml
@@ -2,17 +2,17 @@
 - name: Install php-fpm and deps
   dnf: name={{ item }} state=latest
   with_items:
-    - php
-    - php-fpm
-    - php-enchant
-    - php-IDNA_Convert
-    - php-mbstring
-    - php-mysqlnd
-    - php-PHPMailer
-    - php-process
-    - php-simplepie
-    - php-xml
-    - php-gd
+    - php74
+    - php74-php-fpm
+    - php74-php-enchant
+    # - php-IDNA_Convert 2014年にて開発終了のためコメントアウト
+    - php74-php-mbstring
+    - php74-php-mysqlnd
+    # - php-PHPMailer remi-php74 から外されたためコメントアウト
+    - php74-php-process
+    # - php-simplepie remi-php74 から外されたためコメントアウト
+    - php74-php-xml
+    - php74-php-gd
 
 - name: Disable default pool
   command: mv /etc/php-fpm.d/www.conf /etc/php-fpm.d/www.disabled creates=/etc/php-fpm.d/www.disabled


### PR DESCRIPTION
# CentOS8 詳細対応  

## 完了事項
- nginx , php-fpm , mariadbの各パッケージの導入は完了  
- nginx 内で発生していたNginx Duplicate Default Serverエラーは dafault.confのほかにnginx.confの直接上書きで解決  
-MariaDBにおけるPythonライブラリ不足はrpm直インストールで解決  
<br>  

## 未了事項  
- MariaDBにおけるデータベースログインの資格情報が渡らない。(/root/.my.cnfに記載してるがダメ)   
- 上記ログイン失敗により、wordpressのデータベース構築未了  
<br>  

以上